### PR TITLE
Rename main/memo arg "spec-reg-exp" to "spec-include-reg-exp" and add…

### DIFF
--- a/lib/idl/memos.es6.js
+++ b/lib/idl/memos.es6.js
@@ -35,10 +35,12 @@ const SplitCache = require('../cache/SplitCache.es6.js');
 const html = require('../web/html-entities.es6.js');
 
 // Intended to be configured.
-let specURLRegExp = new RegExp('^$', 'g');
+let specIncludeURLRegExp = new RegExp('^$', 'g');
+let specExcludeURLRegExp = new RegExp('^$', 'g');
 
 function configure(argv) {
-  specURLRegExp = argv['spec-reg-exp'];
+  specIncludeURLRegExp = argv['spec-include-reg-exp'];
+  specExcludeURLRegExp = argv['spec-exclude-reg-exp'];
 }
 
 function pcache(name) {
@@ -149,7 +151,10 @@ const fetchURL = () => new Memo({
 // Output: Filtered array of URLs that are web specs.
 const filterSpecURLs = () => new Memo({
   f: urls => {
-    return urls.filter(url => !!url.match(specURLRegExp));
+    return urls.filter(
+      url => !!url.match(specIncludeURLRegExp) &&
+        !url.match(specExcludeURLRegExp)
+    );
   }
 });
 

--- a/main/memo.es6.js
+++ b/main/memo.es6.js
@@ -51,9 +51,13 @@ const argv = yargs
       .describe('blink-dir', 'Chromium Blink source directory for IDL/URL scraping')
       .coerce('blink-dir', dir => path.resolve(dir))
 
-      .default('spec-reg-exp', '(dev[.]w3[.]org|[.]github[.]io|spec[.]whatwg[.]org|css-houdini[.]org|csswg[.]org|khronos[.]org|dvcs.w3.org/hg/speech-api/raw-file/tip/webspeechapi[.]html)')
-      .describe('spec-reg-exp', 'Regular expression for identifying URLs as current web specification documents')
-      .coerce('spec-reg-exp', re => new RegExp(re, 'g'))
+      .default('spec-include-reg-exp', '(dev[.]w3[.]org|[.]github[.]io|spec[.]whatwg[.]org|css-houdini[.]org|csswg[.]org|www[.]khronos[.]org/(registry/webgl/specs/latest/2[.]0|registry/typedarray/specs/latest)|dvcs.w3.org/hg/speech-api/raw-file/tip/webspeechapi[.]html)')
+      .describe('spec-include-reg-exp', 'Regular expression for identifying URLs as current web specification documents')
+      .coerce('spec-include-reg-exp', re => new RegExp(re, 'g'))
+
+      .default('spec-exclude-reg-exp', 'web[.]archive[.]org')
+      .describe('spec-exclude-reg-exp', 'Regular expression for blacklisting URLs that otherwise appear to be current web specification documents')
+      .coerce('spec-exclude-reg-exp', re => new RegExp(re, 'g'))
   )
   .command(
     'scrape-urls [urls..]',


### PR DESCRIPTION
… "spec-exclude-reg-exp". Implement whitelist-then-blacklist of URLs in spec scraping pipeline