### PR TITLE
Update idl_checkers.es6.js

### DIFF
--- a/lib/idl/idl_checkers.es6.js
+++ b/lib/idl/idl_checkers.es6.js
@@ -289,34 +289,24 @@ Right: ${right.url}`);
       logger.info(`${name}: Parses from
 Left:  ${left.url}
 Right: ${right.url}`);
-        rm = rmsf[chooseBestIdx(lm, rmsf)];
+        rm = rmsf[
+          (lm, rmsf)];
       } else {
         rm = rmsf[0];
       }
 
       const las = lm.args;
       const ras = rm.args || [];
-      for (let i = 0; i < las.length; i++) {
-        const rasf = ras.filter(ra => ra.name === lm.args[i].name);
-        if (rasf.length === 0) {
-          logger.warn(`${name}.${lm.name}.arg${i}:${lm.args[i].name}: No right arg with this name`);
-          continue;
+      var olas = [];
+      var oras = [];
+      for (let i = 0; i < las.length && i < ras.length; i++) {
+        if (!las[i].optional && ras[i].optional) {
+          olas.push(las[i].name);
+          oras.push(ras[i].name);
         }
-
-        const la = las[i];
-        let ra;
-        if (rasf.length > 1) {
-          logger.warn(`${name}.${lm.name}.arg${i}:${lm.args[i].name}: Multiple right args with this name`);
-          ra = rasf[chooseBestIdx(la, rasf)];
-        } else {
-          ra = rasf[0];
-        }
-        if ((!la.optional) && ra.optional) {
-          logger.error(`${name}.${lm.name}.arg${i}:${la.name}: Left is non-optional, but right is optional`);
-          logger.info(`${name}.${lm.name}.arg${i}:${la.name} are:
-Left: ${stringify(la)}
-Right: ${stringify(ra)})`);
-        }
+      }
+      if (olas.length > 0) {
+        logger.error(`${name}.${lm.name}`);
       }
     }
   },

--- a/lib/idl/idl_checkers.es6.js
+++ b/lib/idl/idl_checkers.es6.js
@@ -289,8 +289,7 @@ Right: ${right.url}`);
       logger.info(`${name}: Parses from
 Left:  ${left.url}
 Right: ${right.url}`);
-        rm = rmsf[
-          (lm, rmsf)];
+        rm = rmsf[chooseBestIdx(lm, rmsf)];
       } else {
         rm = rmsf[0];
       }
@@ -307,6 +306,10 @@ Right: ${right.url}`);
       }
       if (olas.length > 0) {
         logger.error(`${name}.${lm.name}`);
+        logger.info(`Left has:
+${stringify(olas)}
+Right has:
+${stringify(oras)}`);
       }
     }
   },


### PR DESCRIPTION
Some methods do not have matching argument names. So checking matching argument name in right adds optional is unnecessary. 

Philip and I both agree that we should keep the report as dense as possible. So I removed bunch of unwanted information.