### PR TITLE
Fix dev_env.sh for bash

### DIFF
--- a/scripts/dev_env.sh
+++ b/scripts/dev_env.sh
@@ -1,8 +1,10 @@
-#!/bin/zsh
-
 # Source this file to setup development environment
 
-WD=$(readlink -f $(dirname "$0"))
+if [ "$(basename $SHELL)" == "bash" ]; then
+  WD=$(readlink -f $(dirname "$BASH_SOURCE"))
+else
+  WD=$(readlink -f $(dirname "$0"))
+fi
 
 NODE_PATH=$WD/..
 NODEJS_BIN=$WD/../node_modules/.bin


### PR DESCRIPTION
Dropping the shebang to `zsh` and treating bash as a special case for detecting the script directory should fix environment setup when `SHELL` is `/bin/bash`